### PR TITLE
Accessor methods init

### DIFF
--- a/PDFExporter/PDFRender/PDFPrintPageRenderer.m
+++ b/PDFExporter/PDFRender/PDFPrintPageRenderer.m
@@ -45,10 +45,10 @@ static UIEdgeInsets const kDefaultPaperInsets = {30.f, 30.f, 30.f, 30.f};
 
 - (instancetype)init {
     if (self = [super init]) {
-        self.paperSize = PDFPaperSizeUSLetter;
-        self.pageOrientation = PDFPageOrientationPortrait;
-        self.paperInset = kDefaultPaperInsets;
-        self.pagingMask = PDFPagingOptionNone;
+        _paperSize = PDFPaperSizeUSLetter;
+        _pageOrientation = PDFPageOrientationPortrait;
+        _paperInset = kDefaultPaperInsets;
+        _pagingMask = PDFPagingOptionNone;
     }
     
     return self;


### PR DESCRIPTION
Use instance variable in initializer instead of properties.
Address [issue](https://github.com/3pillarlabs/ios-PDFexporter/issues/3).